### PR TITLE
fixed prop types

### DIFF
--- a/packages/react-nipple/README.md
+++ b/packages/react-nipple/README.md
@@ -1,3 +1,7 @@
+# NOTICE
+
+The [original repo](https://github.com/loopmode/react-nipple) is no longer maintained so I created this fork to fix the annoying warning about prop types. Here is my open [pull request](https://github.com/loopmode/react-nipple/pull/54). 
+
 # react-nipple
 
 A react wrapper for the [nipplejs](https://www.npmjs.com/package/nipplejs) on-screen-joystick.

--- a/packages/react-nipple/lib/ReactNipple.js
+++ b/packages/react-nipple/lib/ReactNipple.js
@@ -255,9 +255,9 @@ var ReactNipple = (_class = function (_Component) {
                 className: _propTypes2.default.string,
                 options: _propTypes2.default.shape({
                     color: _propTypes2.default.string,
-                    size: _propTypes2.default.integer,
-                    threshold: _propTypes2.default.float, // before triggering a directional event
-                    fadeTime: _propTypes2.default.integer, // transition time
+                    size: _propTypes2.default.number,
+                    threshold: _propTypes2.default.number, // before triggering a directional event
+                    fadeTime: _propTypes2.default.number, // transition time
                     multitouch: _propTypes2.default.bool,
                     maxNumberOfNipples: _propTypes2.default.number, // when multitouch, what is too many?
                     dataOnly: _propTypes2.default.bool, // no dom element whatsoever

--- a/packages/react-nipple/package.json
+++ b/packages/react-nipple/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "react-nipple",
-  "version": "1.0.3",
+  "name": "@mjforan/react-nipple",
+  "version": "1.0.6",
   "main": "lib/index.js",
   "license": "MIT",
   "scripts": {
@@ -25,5 +25,23 @@
   "devDependencies": {
     "@loopmode/babel6-base": "^0.0.6",
     "react": "^16.4.1"
-  }
+  },
+  "description": "A react wrapper for the [nipplejs](https://www.npmjs.com/package/nipplejs) on-screen-joystick (with fixed prop-types).",
+  "directories": {
+    "lib": "lib"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mjforan/react-nipple.git"
+  },
+  "keywords": [
+    "react",
+    "nipple",
+    "joystick"
+  ],
+  "author": "Jovica Aleksic",
+  "bugs": {
+    "url": "https://github.com/mjforan/react-nipple/issues"
+  },
+  "homepage": "https://github.com/mjforan/react-nipple/tree/master/packages/react-nipple#readme"
 }

--- a/packages/react-nipple/src/ReactNipple.js
+++ b/packages/react-nipple/src/ReactNipple.js
@@ -38,9 +38,9 @@ export default class ReactNipple extends Component {
             className: PropTypes.string,
             options: PropTypes.shape({
                 color: PropTypes.string,
-                size: PropTypes.integer,
-                threshold: PropTypes.float, // before triggering a directional event
-                fadeTime: PropTypes.integer, // transition time
+                size: PropTypes.number,
+                threshold: PropTypes.number, // before triggering a directional event
+                fadeTime: PropTypes.number, // transition time
                 multitouch: PropTypes.bool,
                 maxNumberOfNipples: PropTypes.number, // when multitouch, what is too many?
                 dataOnly: PropTypes.bool, // no dom element whatsoever


### PR DESCRIPTION
JavaScript doesn't have separate integer and float types, just "number". You can see the available prop types [here](https://github.com/facebook/prop-types/blob/main/factoryWithThrowingShims.js). This was causing the console to display  ```Warning: Failed prop type: ReactNipple: prop type `options.size` is invalid; it must be a function, usually from the `prop-types` package, but received `undefined`.```